### PR TITLE
Made invasion board generation consistent with board seed

### DIFF
--- a/generators/invasionGen.py
+++ b/generators/invasionGen.py
@@ -12,6 +12,7 @@ def genInvasionBoard(json, seed):
 	cutoff2 = 20
 	batch3 = [7,11,12,13,17]
 
+	random.seed(seed)
 	random.shuffle(batch1)
 	random.shuffle(batch2)
 	random.shuffle(batch3)


### PR DESCRIPTION
Previously generating 2 invasion boards with the same seed could result with different boards. Now it always generates the same board for a given seed.